### PR TITLE
intmap: let ForEach stop early

### DIFF
--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -43,8 +43,9 @@ func TestMapSimple(t *testing.T) {
 	}
 	n := len(m0)
 
-	m.ForEach(func(k int64, v int64) {
+	m.ForEach(func(k int64, v int64) bool {
 		m0[k] = -k
+		return true
 	})
 
 	if n != len(m0) {
@@ -66,11 +67,12 @@ func TestMapSimple(t *testing.T) {
 	}
 	n = len(m0)
 
-	m.ForEach(func(k int64, v int64) {
+	m.ForEach(func(k int64, v int64) bool {
 		m0[k] = -v
 		if k != v {
 			t.Errorf("didn't get expected key-value pair")
 		}
+		return true
 	})
 
 	if n != len(m0) {

--- a/map64_test.go
+++ b/map64_test.go
@@ -89,9 +89,10 @@ func TestNilMap(t *testing.T) {
 	}
 
 	count := 0
-	m.ForEach(func(i int, i2 int) {
+	m.ForEach(func(i int, i2 int) bool {
 		count++
 		t.Fatalf("must not be reached, nil map has no elements")
+		return true
 	})
 	if count != 0 {
 		t.Fatalf("iterating over nil map must not yield")
@@ -164,5 +165,22 @@ func TestMap64PutIfNotExists(t *testing.T) {
 		if val != -i {
 			t.Fatalf("key should have been there: %d", i)
 		}
+	}
+}
+
+func TestMap64ForEachStop(t *testing.T) {
+	m := New[int, int](10)
+	for i := 0; i < 100; i++ {
+		m.Put(i, -i)
+	}
+
+	count := 0
+	m.ForEach(func(k, v int) bool {
+		count++
+		return count < 50
+	})
+
+	if have, want := count, 50; have != want {
+		t.Fatalf("unexpected number of elements processed: %d, want %d", have, want)
 	}
 }

--- a/set.go
+++ b/set.go
@@ -30,8 +30,8 @@ func (s *Set[K]) Len() int {
 
 // ForEach iterates the elements in the set.
 // This method returns immediately if the set is nil.
-func (s *Set[K]) ForEach(visit func(k K)) {
-	(*Map[K, struct{}])(s).ForEach(func(k K, _ struct{}) {
-		visit(k)
+func (s *Set[K]) ForEach(visit func(k K) bool) {
+	(*Map[K, struct{}])(s).ForEach(func(k K, _ struct{}) bool {
+		return visit(k)
 	})
 }

--- a/set_test.go
+++ b/set_test.go
@@ -34,8 +34,9 @@ func TestSet(t *testing.T) {
 	}
 
 	sum := 0
-	s.ForEach(func(k int) {
+	s.ForEach(func(k int) bool {
 		sum += k
+		return true
 	})
 	if sum != 3 {
 		t.Fatalf("total sum of elements must be 3")
@@ -54,8 +55,9 @@ func TestNilSet(t *testing.T) {
 	}
 
 	count := 0
-	s.ForEach(func(k int) {
+	s.ForEach(func(k int) bool {
 		count++
+		return true
 	})
 	if count != 0 {
 		t.Fatalf("total count of elements in nil set must be 0")


### PR DESCRIPTION
This commit changes the signature of the closure passed to ForEach so that it returns a boolean, which determines if the iteration should stop early or continue.