### PR TITLE
test: Enable test on 32bit system

### DIFF
--- a/map64.go
+++ b/map64.go
@@ -19,8 +19,8 @@ type pair[K IntKey, V any] struct {
 const fillFactor64 = 0.7
 
 func phiMix64(x int) int {
-	h := x * 0x9E3779B9
-	return h ^ (h >> 16)
+	h := int64(x) * int64(0x9E3779B9)
+	return int(h ^ (h >> 16))
 }
 
 // Map is a hashmap where the keys are some any integer type.
@@ -251,7 +251,7 @@ func (m *Map[K, V]) Keys() iter.Seq[K] {
 		if m.hasZeroKey && !yield(K(0)) {
 			return
 		}
-	
+
 		for _, p := range m.data {
 			if p.K != K(0) && !yield(p.K) {
 				return

--- a/map64_test.go
+++ b/map64_test.go
@@ -223,3 +223,53 @@ func TestMap64Iterators(t *testing.T) {
 		t.Fatalf("unexpected sum when iterating over values: %d, want %d", sum, sumTo99*2)
 	}
 }
+
+func TestPhiMix64(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    int
+		expected func(int) int
+	}{
+		{
+			name:  "zero",
+			input: 0,
+			expected: func(x int) int {
+				return 0
+			},
+		},
+		{
+			name:  "one",
+			input: 1,
+			expected: func(x int) int {
+				h := int64(x) * 0x9E3779B9
+				return int(h ^ (h >> 16))
+			},
+		},
+		{
+			name:  "negative_one",
+			input: -1,
+			expected: func(x int) int {
+				h := int64(x) * 0x9E3779B9
+				return int(h ^ (h >> 16))
+			},
+		},
+		{
+			name:  "large_number",
+			input: 1234567,
+			expected: func(x int) int {
+				h := int64(x) * 0x9E3779B9
+				return int(h ^ (h >> 16))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := phiMix64(tc.input)
+			expected := tc.expected(tc.input)
+			if result != expected {
+				t.Errorf("phiMix64(%d) = %d; want %d", tc.input, result, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As seen in [this](https://github.com/grafana/loki/actions/runs/12343942387/job/34453913880) build failure, the current 0.5.0 version does not test cleanly on a 32 bit system.  

This PR casts the int values to int64 values to take this into consideration.

I have tested this on a 64 bit Darwin system, and a 32 bit Linux system.