### PR TITLE
set: reduce Set memory usage by half

### DIFF
--- a/map64.go
+++ b/map64.go
@@ -16,7 +16,8 @@ type pair[K IntKey, V any] struct {
 	V V
 }
 
-const fillFactor64 = 0.7
+const fillFactorBase64 = 7
+const fillFactor64 = fillFactorBase64 / 10.0
 
 func phiMix64(x int) int {
 	h := int64(x) * int64(0x9E3779B9)
@@ -324,15 +325,15 @@ func (m *Map[K, V]) Len() int {
 }
 
 func (m *Map[K, V]) sizeThreshold() int {
-	return int(math.Floor(float64(len(m.data)) * fillFactor64))
+	return int(uint64(len(m.data)) * fillFactorBase64 / 10)
 }
 
 func (m *Map[K, V]) startIndex(key K) int {
-	return phiMix64(int(key)) & (len(m.data) - 1)
+	return startIndex(int(key), len(m.data))
 }
 
 func (m *Map[K, V]) nextIndex(idx int) int {
-	return (idx + 1) & (len(m.data) - 1)
+	return nextIndex(idx, len(m.data))
 }
 
 func forEach64[K IntKey, V any](pairs []pair[K, V], f func(k K, v V) bool) {
@@ -439,4 +440,12 @@ func arraySize(exp int, fill float64) int {
 		s = 2
 	}
 	return int(s)
+}
+
+func startIndex(key, len int) int {
+	return phiMix64(key) & (len - 1)
+}
+
+func nextIndex(idx, len int) int {
+	return (idx + 1) & (len - 1)
 }

--- a/set.go
+++ b/set.go
@@ -5,39 +5,152 @@ import "iter"
 // Set is a specialization of Map modelling a set of integers.
 // Like Map, methods that read from the set are valid on the nil Set.
 // This include Has, Len, and ForEach.
-type Set[K IntKey] Map[K, struct{}]
+type Set[K IntKey] struct {
+	data       []K
+	size       int
+	hasZeroKey bool
+}
 
-// NewSet creates a new Set with a given initial capacity.
+// New creates a new map with keys being any integer subtype.
+// The map can store up to the given capacity before reallocation and rehashing occurs.
 func NewSet[K IntKey](capacity int) *Set[K] {
-	return (*Set[K])(New[K, struct{}](capacity))
+	return &Set[K]{
+		data: make([]K, arraySize(capacity, fillFactor64)),
+	}
 }
 
 // Add an element to the set. Returns true if the element was not already present.
-func (s *Set[K]) Add(k K) bool {
-	_, found := (*Map[K, struct{}])(s).PutIfNotExists(k, struct{}{})
-	return found
+func (s *Set[K]) Add(key K) bool {
+	if key == K(0) {
+		exists := s.hasZeroKey
+		if !exists {
+			s.size++
+			s.hasZeroKey = true
+		}
+		return !exists
+	}
+
+	idx := s.startIndex(key)
+	p := s.data[idx]
+	if p == key {
+		return false
+	}
+
+	sizeThreshold := s.sizeThreshold()
+	if p == K(0) { // end of chain already
+		s.data[idx] = key
+		if s.size >= sizeThreshold {
+			s.rehash()
+		} else {
+			s.size++
+		}
+		return true
+	}
+
+	// hash collision, seek next empty or key match
+	for {
+		idx = s.nextIndex(idx)
+		p = s.data[idx]
+		if p == K(0) {
+			s.data[idx] = key
+			if s.size >= sizeThreshold {
+				s.rehash()
+			} else {
+				s.size++
+			}
+			return true
+		} else if p == key {
+			// Value already present
+			return false
+		}
+	}
 }
 
-// Del deletes a key, returning true iff the key was found
-func (s *Set[K]) Del(k K) bool {
-	return (*Map[K, struct{}])(s).Del(k)
+// Del deletes a key, returning true if the key was found.
+func (s *Set[K]) Del(key K) bool {
+	if key == K(0) {
+		if s.hasZeroKey {
+			s.hasZeroKey = false
+			s.size--
+			return true
+		}
+		return false
+	}
+
+	idx := s.startIndex(key)
+	p := s.data[idx]
+	if p == key {
+		s.shiftKeys(idx)
+		s.size--
+		return true
+	}
+	if p == K(0) {
+		return false
+	}
+
+	// hash collision, seek next empty or key match
+	for {
+		idx = s.nextIndex(idx)
+		p = s.data[idx]
+		if p == key {
+			s.shiftKeys(idx)
+			s.size--
+			return true
+		} else if p == K(0) {
+			// Value already present
+			return false
+		}
+	}
 }
 
 // Clear removes all items from the Set, but keeps the internal buffers for reuse.
 func (s *Set[K]) Clear() {
-	(*Map[K, struct{}])(s).Clear()
+	s.hasZeroKey = false
+	s.size = 0
+	clear(s.data)
 }
 
-// Has returns true if the key is in the set.
-// If the set is nil this method always return false.
-func (s *Set[K]) Has(k K) bool {
-	return (*Map[K, struct{}])(s).Has(k)
+// Has checks if the given key exists in the map.
+// Calling this method on a nil map will return false.
+func (s *Set[K]) Has(key K) bool {
+	if s == nil {
+		return false
+	}
+
+	if key == K(0) {
+		return s.hasZeroKey
+	}
+
+	idx := s.startIndex(key)
+	p := s.data[idx]
+
+	if p == K(0) { // end of chain already
+		return false
+	}
+	if p == key { // we check zero prior to this call
+		return true
+	}
+
+	// hash collision, seek next hash match, bailing on first empty
+	for {
+		idx = s.nextIndex(idx)
+		p = s.data[idx]
+		if p == K(0) {
+			return false
+		}
+		if p == key {
+			return true
+		}
+	}
 }
 
 // Len returns the number of elements in the set.
 // If the set is nil this method return 0.
 func (s *Set[K]) Len() int {
-	return (*Map[K, struct{}])(s).Len()
+	if s == nil {
+		return 0
+	}
+	return s.size
 }
 
 // ForEach iterates over the elements in the set while the visit function returns true.
@@ -45,9 +158,17 @@ func (s *Set[K]) Len() int {
 //
 // The iteration order of a Set is not defined, so please avoid relying on it.
 func (s *Set[K]) ForEach(visit func(k K) bool) {
-	(*Map[K, struct{}])(s).ForEach(func(k K, _ struct{}) bool {
-		return visit(k)
-	})
+	if s == nil {
+		return
+	}
+	if s.hasZeroKey && !visit(K(0)) {
+		return
+	}
+	for _, k := range s.data {
+		if k != K(0) && !visit(k) {
+			return
+		}
+	}
 }
 
 // All returns an iterator over keys from the set.
@@ -56,4 +177,67 @@ func (s *Set[K]) ForEach(visit func(k K) bool) {
 // The iteration order of a Set is not defined, so please avoid relying on it.
 func (s *Set[K]) All() iter.Seq[K] {
 	return s.ForEach
+}
+
+func (s *Set[K]) shiftKeys(idx int) int {
+	// Shift entries with the same hash.
+	// We need to do this on deletion to ensure we don't have zeroes in the hash chain
+	for {
+		var p K
+		lastIdx := idx
+		idx = s.nextIndex(idx)
+		for {
+			p = s.data[idx]
+			if p == K(0) {
+				s.data[lastIdx] = 0
+				return lastIdx
+			}
+
+			slot := s.startIndex(p)
+			if lastIdx <= idx {
+				if lastIdx >= slot || slot > idx {
+					break
+				}
+			} else {
+				if lastIdx >= slot && slot > idx {
+					break
+				}
+			}
+			idx = s.nextIndex(idx)
+		}
+		s.data[lastIdx] = p
+	}
+}
+
+func (s *Set[K]) rehash() {
+	oldData := s.data
+	s.data = make([]K, 2*len(s.data))
+
+	// reset size
+	if s.hasZeroKey {
+		s.size = 1
+	} else {
+		s.size = 0
+	}
+
+	if s.hasZeroKey {
+		s.Add(K(0))
+	}
+	for _, k := range oldData {
+		if k != 0 {
+			s.Add(k)
+		}
+	}
+}
+
+func (s *Set[K]) sizeThreshold() int {
+	return int(uint64(len(s.data)) * fillFactorBase64 / 10)
+}
+
+func (s *Set[K]) startIndex(key K) int {
+	return startIndex(int(key), len(s.data))
+}
+
+func (s *Set[K]) nextIndex(idx int) int {
+	return nextIndex(idx, len(s.data))
 }

--- a/set_test.go
+++ b/set_test.go
@@ -1,6 +1,13 @@
 package intmap
 
-import "testing"
+import (
+	"maps"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+	"unsafe"
+)
 
 func TestSet(t *testing.T) {
 	s := NewSet[int](0)
@@ -29,7 +36,7 @@ func TestSet(t *testing.T) {
 		t.Fatalf("length of set must be 2: %d", sz)
 	}
 
-	if !(s.Has(1) && s.Has(2)) {
+	if !s.Has(1) || !s.Has(2) {
 		t.Fatalf("set must have both 1 and 2")
 	}
 
@@ -46,12 +53,13 @@ func TestSet(t *testing.T) {
 func TestSetClear(t *testing.T) {
 	s := NewSet[int](0)
 
+	s.Add(0)
 	s.Add(1)
 	s.Add(2)
-	if sz := s.Len(); sz != 2 {
+	if sz := s.Len(); sz != 3 {
 		t.Fatalf("unexpected set len %d", sz)
 	}
-	if !s.Has(1) || !s.Has(2) {
+	if !s.Has(0) || !s.Has(1) || !s.Has(2) {
 		t.Fatalf("set must contain 1 and 2 before Clear()")
 	}
 
@@ -59,8 +67,88 @@ func TestSetClear(t *testing.T) {
 	if sz := s.Len(); sz != 0 {
 		t.Fatalf("unexpected set len %d", sz)
 	}
-	if s.Has(1) || s.Has(2) {
+	if s.Has(0) || s.Has(1) || s.Has(2) {
 		t.Fatalf("set must not contain 1 or 2 after Clear()")
+	}
+}
+
+// Reference Set implementation.
+type RefSet[K IntKey] struct {
+	m *Map[K, struct{}]
+}
+
+func (s *RefSet[K]) init() {
+	if s.m == nil {
+		s.m = New[K, struct{}](10)
+	}
+}
+
+func (s *RefSet[K]) Len() int {
+	return s.m.Len()
+}
+
+func (s *RefSet[K]) Has(k K) bool {
+	s.init()
+	return s.m.Has(k)
+}
+
+func (s *RefSet[K]) Del(k K) bool {
+	return s.m.Del(k)
+}
+
+func (s *RefSet[K]) Add(k K) bool {
+	s.init()
+	_, ok := s.m.PutIfNotExists(k, struct{}{})
+	return ok
+}
+
+func (s *RefSet[K]) ForEach(f func(K) bool) {
+	s.m.ForEach(func(k K, _ struct{}) bool {
+		return f(k)
+	})
+}
+
+func TestSetExhaustive(t *testing.T) {
+	s := NewSet[int](0)
+	m := RefSet[int]{}
+
+	test := func(t *testing.T, op string, key int, got, want any) {
+		t.Helper()
+		if got != want {
+			t.Errorf("%s(%d) = %v; want: %v", op, key, got, want)
+		}
+	}
+
+	rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for range 100_000 {
+		k := rr.Intn(10_000)
+		ff := rr.Float64()
+		if ff >= 0.5 {
+			test(t, "Has", k, s.Has(k), m.Has(k))
+			test(t, "Add", k, s.Add(k), m.Add(k))
+			test(t, "Has", k, s.Has(k), true)
+			test(t, "Len", k, s.Len(), m.Len())
+		} else {
+			test(t, "Has", k, s.Has(k), m.Has(k))
+			test(t, "Del", k, s.Del(k), m.Del(k))
+			test(t, "Has", k, s.Has(k), false)
+			test(t, "Len", k, s.Len(), m.Len())
+		}
+		// Test ForEach
+		if ff <= 0.01 {
+			keys := make(map[int]struct{}, m.Len())
+			m.ForEach(func(k int) bool {
+				keys[k] = struct{}{}
+				return true
+			})
+			s.ForEach(func(k int) bool {
+				delete(keys, k)
+				return true
+			})
+			if len(keys) != 0 {
+				t.Errorf("ForEach: failed to visit the following keys: %+v", keys)
+			}
+		}
 	}
 }
 
@@ -145,5 +233,107 @@ func TestSetIter(t *testing.T) {
 	const sumTo99 = 99 * (99 + 1) / 2
 	if sum != sumTo99 {
 		t.Fatalf("unexpected sum: %d, want %d", sum, sumTo99)
+	}
+}
+
+func testSetMemoryUsage[K IntKey]() func(t *testing.T) {
+	return func(t *testing.T) {
+		s := NewSet[K](16)
+		m := New[K, struct{}](16)
+		szs := int(unsafe.Sizeof(s.data[0]))
+		msz := int(unsafe.Sizeof(m.data[0]))
+		if szs*2 < msz {
+			t.Fatalf("The per-element size of Set[%T] (%d) should be half that of Map[%T] (%d)",
+				s.data[0], szs, m.data[0], msz)
+		}
+		t.Logf("Sizeof(Set[%T]) = %d; Sizeof(Map[%T]) = %d",
+			s.data[0], szs, m.data[0], msz)
+	}
+}
+
+func TestSetMemoryUsage(t *testing.T) {
+	t.Run("int", testSetMemoryUsage[int]())
+	t.Run("int8", testSetMemoryUsage[int8]())
+	t.Run("int16", testSetMemoryUsage[int16]())
+	t.Run("int32", testSetMemoryUsage[int32]())
+	t.Run("int64", testSetMemoryUsage[int64]())
+
+	t.Run("uint", testSetMemoryUsage[uint]())
+	t.Run("uint8", testSetMemoryUsage[uint8]())
+	t.Run("uint16", testSetMemoryUsage[uint16]())
+	t.Run("uint32", testSetMemoryUsage[uint32]())
+	t.Run("uint64", testSetMemoryUsage[uint64]())
+}
+
+func BenchmarkSetAdd10K(b *testing.B) {
+	rr := rand.New(rand.NewSource(12345))
+	seen := make(map[int]struct{}, 10_000)
+	for len(seen) < 10_000 {
+		seen[int(rr.Int31())] = struct{}{}
+	}
+	keys := slices.AppendSeq(make([]int, 0, 10_000), maps.Keys(seen))
+
+	s := NewSet[int](10_000)
+	b.ResetTimer()
+
+	j := 0
+	for i := 0; i < b.N; i++ {
+		s.Add(keys[j])
+		j++
+		if j == 10_000 {
+			j = 0
+			s.Clear()
+		}
+	}
+}
+
+func BenchmarkSetDel10K(b *testing.B) {
+	rr := rand.New(rand.NewSource(12345))
+
+	s := NewSet[int](10_000)
+	keys := make([]int, 0, 10_000)
+	for s.Len() < 10_000 {
+		v := rr.Int()
+		if s.Add(v) {
+			keys = append(keys, v)
+		}
+	}
+
+	// Duplicate S to make resetting it back
+	// to a populated state faster.
+	dup := *s
+	dup.data = slices.Clone(dup.data)
+
+	b.ResetTimer()
+
+	j := 0
+	for i := 0; i < b.N; i++ {
+		s.Del(keys[j])
+		j++
+		if j == 10_000 {
+			j = 0
+			b.StopTimer()
+			copy(s.data, dup.data)
+			s.size = dup.size
+			s.hasZeroKey = dup.hasZeroKey
+			b.StartTimer()
+		}
+	}
+}
+
+func BenchmarkSetHas(b *testing.B) {
+	rr := rand.New(rand.NewSource(12345))
+	s := NewSet[int32](256)
+	var keys [32]int32
+	for i := 0; s.Len() < 256; i++ {
+		v := int32(rr.Int31())
+		if s.Add(v) && i < len(keys) {
+			keys[i] = v
+			i++
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Has(keys[i%len(keys)])
 	}
 }


### PR DESCRIPTION
This commit adds a standalone Set implementation that no longer relies on the Map type. This reduces memory usage by half since a pair of `[IntKey, struct{}]` (the datatype that underlies the Map) has a size of `2 * sizeof(IntKey)`. By using a standalone Set implementation we only need to store the key - therefore we only need a backing slice of type IntKey (not `pair[IntKey, struct{}]`).